### PR TITLE
Define global HTML escape helper

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -1,6 +1,13 @@
 <?php
 declare(strict_types=1);
 
+if (!function_exists('e')) {
+    function e(?string $v): string
+    {
+        return htmlspecialchars($v ?? '', ENT_QUOTES, 'UTF-8');
+    }
+}
+
 /**
  * Fetches exchange rates for the given currencies relative to the base.
  *


### PR DESCRIPTION
## Summary
- ensure the HTML escaping helper `e()` is available globally by defining it in `helpers.php`
- guard the helper with `function_exists` to avoid redeclaration when other files define it

## Testing
- php -l helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68cd3691555083289ab74c8402c9fdcf