### PR TITLE
Allow zero remote quantity in guillotine form

### DIFF
--- a/quotation_view.php
+++ b/quotation_view.php
@@ -927,7 +927,7 @@ page_header($title, $actions, true);
                         </div>
                         <div class="col-md-6">
                             <label for="remote_quantity" class="form-label">Kumanda Adedi</label>
-                            <input type="number" min="1" step="1" class="form-control" id="remote_quantity" name="remote_quantity" placeholder="0">
+                            <input type="number" min="0" step="1" class="form-control" id="remote_quantity" name="remote_quantity" placeholder="0">
                             <div class="form-text">adet</div>
                         </div>
                         <div class="col-md-6">


### PR DESCRIPTION
## Summary
- allow remote quantity in the guillotine modal to be zero by relaxing the HTML input minimum

## Testing
- browser_container.run_playwright_script (submit guillotine form with blank remote quantity)


------
https://chatgpt.com/codex/tasks/task_e_68cd55e196148328b912de1de3b183a3